### PR TITLE
Minor fixes for labels and tooltips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 *.pyc
 package-lock.json
+.DS_Store
+metadata/local.meta

--- a/app.manifest
+++ b/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "missile_map",
-      "version": "1.5.1"
+      "version": "1.6"
     },
     "author": [
       {

--- a/appserver/static/visualizations/missile_map/README.md
+++ b/appserver/static/visualizations/missile_map/README.md
@@ -47,6 +47,7 @@ The following options are available to customise:
  	* Latitude: Starting latitude to load
  	* Longitude: Starting longitude to load
  	* Zoom: Starting zoom level to load
+  * Show Labels: Toggle to show/hide labels or latitude and longitude (default)
 
 # Support contact
 

--- a/appserver/static/visualizations/missile_map/formatter.html
+++ b/appserver/static/visualizations/missile_map/formatter.html
@@ -41,10 +41,9 @@
         <splunk-text-input name="{{VIZ_NAMESPACE}}.mapZoom" value="5"></splunk-text-input>
     </splunk-control-group>
     <splunk-control-group label="Show Labels">
-        <splunk-radio-input name="{{VIZ_NAMESPACE}}.showLabels" value="custom">
-            <option value="all">All</option>
-            <option value="custom">Custom only</option>
-            <option value="none">None</option>
+        <splunk-radio-input name="{{VIZ_NAMESPACE}}.showLabels" value="1">
+            <option value="1">Yes</option>
+            <option value="0">No</option>
         </splunk-radio-input>
     </splunk-control-group>
 </form>

--- a/appserver/static/visualizations/missile_map/visualization.js
+++ b/appserver/static/visualizations/missile_map/visualization.js
@@ -211,15 +211,15 @@ define(["api/SplunkVisualizationBase","api/SplunkVisualizationUtils"], function(
 	                lon         = this._getEscapedProperty('mapLongitude', config) || -95,
 	                zoom        = this._getEscapedProperty('mapZoom', config) || 5
 
-	            var showLabels  = this._getEscapedProperty('showLabels', config) || "custom";
+	            var showLabels = Splunk.util.normalizeBoolean(this._getEscapedProperty('showLabels', config) || true);
 
 	            if (this.lat != lat || this.lon != lon || this.zoom != zoom) updateBounds = true;
 	            else updateBounds = false;
 
 	            var lineThickness = parseInt(this._getEscapedProperty('lineThickness', config) || 1);
 	            var updateLineWidth = lineThickness != this.activeLineThickness;
-	            var updateShowLabels = (this.activeShowLabels !== undefined) ? 
-	                                        (showLabels != this.activeShowLabels) : false; 
+	            var updateShowLabels = (this.activeShowLabels !== undefined) ?
+	                (showLabels != this.activeShowLabels) : false;
 	            var scrollWheelZoom = Splunk.util.normalizeBoolean(this._getEscapedProperty('scrollWheelZoom', config) || true)
 
 	            this.useDrilldown = this._isEnabledDrilldown(config);
@@ -285,13 +285,13 @@ define(["api/SplunkVisualizationBase","api/SplunkVisualizationUtils"], function(
 	            // to let drilldown be available on the top layer
 
 	            // Get unique end markers only
-	            const markersDest = [...new Map(formatted.map(v => [v.to[0], v] && [v.to[1], v])).values()];
+	            const markersDest =
+	                [...new Map(formatted.map(v => [v.to[0], v] && [v.to[1], v])).values()];
 	            markersDest.forEach(element => {
-	                if (showLabels == "custom" && element.labels[1] !== "" || showLabels == "all") {
-	                  // Add transparent end markers to the layer group to provide tooltips
-	                  let text = "Lat: " + element.to[1] + "\nLon: " + element.to[0];
-	                  let markerText = element.labels[1] === "" ? text : element.labels[1];
-	                  let marker = L.marker([element.to[1], element.to[0]])
+	                // Add transparent end markers to the layer group to provide tooltips
+	                let text = "Lat: " + element.to[1] + "\nLon: " + element.to[0];
+	                let markerText = element.labels[1] === "" ? text : element.labels[1] + "\n" + text;
+	                let marker = L.marker([element.to[1], element.to[0]])
 	                    .setOpacity(0)
 	                    .bindTooltip(markerText, {
 	                        offset: L.point({ x: -10, y: 20 }),
@@ -299,18 +299,22 @@ define(["api/SplunkVisualizationBase","api/SplunkVisualizationUtils"], function(
 	                    })
 	                    .addTo(markersGroup);
 
-	                  marker.openTooltip();
+	                // Show/hide tooltips
+	                if (showLabels) {
+	                    marker.openTooltip();
+	                } else {
+	                    marker.closeTooltip();
 	                }
 	            });
 
 	            // Get unique start markers only
-	            const markersSrc = [...new Map(formatted.map(v => [v.from[0], v] && [v.from[1], v])).values()];
+	            const markersSrc =
+	                [...new Map(formatted.map(v => [v.from[0], v] && [v.from[1], v])).values()];
 	            markersSrc.forEach(element => {
-	                if (showLabels == "custom" && element.labels[0] !== "" || showLabels == "all") {
-	                  // Add transparent start markers to the layer group to provide tooltips and drilldown functionalities
-	                  let text = "Lat: " + element.from[1] + "\nLon: " + element.from[0];
-	                  let markerText = element.labels[0] === "" ? text : element.labels[0];
-	                  let marker = L.marker([element.from[1], element.from[0]])
+	                // Add transparent start markers to the layer group to provide tooltips and drilldown functionalities
+	                let text = "Lat: " + element.from[1] + "\nLon: " + element.from[0];
+	                let markerText = element.labels[0] === "" ? text : element.labels[0] + "\n" + text;
+	                let marker = L.marker([element.from[1], element.from[0]])
 	                    .setOpacity(0)
 	                    .bindTooltip(markerText, {
 	                        offset: L.point({ x: -10, y: 20 }),
@@ -318,9 +322,15 @@ define(["api/SplunkVisualizationBase","api/SplunkVisualizationUtils"], function(
 	                    })
 	                    .addTo(markersGroup);
 
-	                  marker.openTooltip();
-	                  marker.on("click", that._drilldown.bind(this, element));
+	                // Show/hide tooltips
+	                if (showLabels) {
+	                    marker.openTooltip();
+	                } else {
+	                    marker.closeTooltip();
 	                }
+
+	                // Bind to drilldown
+	                marker.on("click", that._drilldown.bind(this, element));
 	            });
 
 	            this.migrationLayer.setData(formatted);


### PR DESCRIPTION
* Reverted feature to show labels
  * Toggle to show/hide all
* Edited tooltips text. In brackets optional values. Format:
```
(<label>)
Lat: <start_lat> / <end_lat>
Lon: <start_lon> / <end_lon>
``` 

`| inputlookup missilemap_testdata.csv` results in:

<img width="1312" alt="image" src="https://github.com/lukemonahan/missile_map/assets/25966020/6240608f-ae41-42fd-9e47-6b40d287acf1">
